### PR TITLE
Fix equality function

### DIFF
--- a/vm/src/primitives.lua
+++ b/vm/src/primitives.lua
@@ -474,7 +474,7 @@ local function equals(a, b)
       end
       return true
     elseif a.cons and b.cons then
-      if a.hd == b.hd then
+      if equals(a.hd, b.hd) then
         return equals(a.tl, b.tl)
       else
         return false


### PR DESCRIPTION
The head of the cons has to be compared recursively with `equals` too, because the value in there may be another non-primitive value that needs special handling.

With this change all failing tests pass except for the quantifier machine one (fails with a stack overflow).